### PR TITLE
USER-245: Add API to use a specific Custom Tabs implementation

### DIFF
--- a/src/android/ChromeCustomTabPlugin.java
+++ b/src/android/ChromeCustomTabPlugin.java
@@ -91,20 +91,20 @@ public class ChromeCustomTabPlugin extends CordovaPlugin{
             }
             case "getViewHandlerPackages": {
                 PluginResult pluginResult;
-                final JSONObject json = new JSONObject();
-                json.put("defaultHandler", CustomTabsHelper.getDefaultViewHandlerPackageName(context));
-                json.put("customTabsImplementations", new JSONArray(CustomTabsHelper.getPackagesSupportingCustomTabs(context)));
-                pluginResult = new PluginResult(PluginResult.Status.OK, json);
+                final JSONObject result = new JSONObject();
+                result.put("defaultHandler", CustomTabsHelper.getDefaultViewHandlerPackageName(context));
+                result.put("customTabsImplementations", new JSONArray(CustomTabsHelper.getPackagesSupportingCustomTabs(context)));
+                pluginResult = new PluginResult(PluginResult.Status.OK, result);
                 callbackContext.sendPluginResult(pluginResult);
                 return true;
             }
             case "useCustomTabsImplementation": {
                 PluginResult pluginResult;
-                JSONObject json = new JSONObject();
+                JSONObject result = new JSONObject();
                 final String packageName = args.optString(0);
                 if(TextUtils.isEmpty(packageName)) {
-                    json.put("error", "blank packageName");
-                    pluginResult = new PluginResult(PluginResult.Status.ERROR, json);
+                    result.put("error", "expected argument 'packageName' to be non empty string.");
+                    pluginResult = new PluginResult(PluginResult.Status.ERROR, result);
                 } else {
                     try {
                         mCustomTabPluginHelper.setPackageNameToBind(packageName, context);

--- a/src/android/helpers/CustomTabServiceHelper.java
+++ b/src/android/helpers/CustomTabServiceHelper.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class CustomTabServiceHelper implements ServiceConnectionCallback {
 
-    private final String mPackageNameToBind;
+    private String mPackageNameToBind;
     private CustomTabsSession mCustomTabsSession;
     private CustomTabsClient mClient;
     private CustomTabsServiceConnection mConnection;
@@ -36,6 +36,11 @@ public class CustomTabServiceHelper implements ServiceConnectionCallback {
 
     public boolean isAvailable(){
         return !TextUtils.isEmpty(mPackageNameToBind);
+    }
+
+    public void setPackageNameToBind(String packageName, Context context) throws CustomTabsHelper.InvalidPackageException {
+        CustomTabsHelper.setPackageNameToUse(packageName, context);
+        mPackageNameToBind = packageName;
     }
 
     /**

--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -19,6 +19,12 @@ module.exports = {
   hide: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "hide", []);
   },
+  getViewHandlerPackages: function (onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "getViewHandlerPackages", []);
+  },
+  useCustomTabsImplementation: function (packageName, onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "useCustomTabsImplementation", [packageName]);
+  },
   connectToService: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "connectToService", []);
   },


### PR DESCRIPTION
https://doxodev.atlassian.net/browse/USER-245

#### What I did
On the Android platform through the `useCustomTabsImplementation(packageName)` API I made it possible to select any of the available Custom Tabs implementations for the in-app-browser, in case the default one is not preferable.

I also added an API (`getViewHandlerPackages()`) to retrieve the package names of the default view handler and of the view handlers that are also Custom Tabs implementations.

This effort is driven by fatal authentication issues in the doxo mobile app. We observed that users on certain devices - e.g. where Firefox is the default browser and the Custom Tabs implementation in the in-app-browser - are unable to log in because in the end of the oauth flow, although Firefox passes the doxo specific custom scheme callback URL to the OS, somehow the doxo app does not receive it as it does when other browsers back the in-app-browser (e.g. Chrome).

~Another issue this change helps address is that on certain devices (at least on LG Aristo, Android 7.0 API level 24) where Opera is installed beside other browsers, the Android APIs return Opera as the only possible view handler. This makes authentication impossible since Opera is not a Custom Tabs implementation.~
**UPDATE**: Albeit valid, seemingly the Opera issue was a temporary glitch on my LG phone. I can no longer repro this.

#### How I did it
Changed the plugin's JS interface and a few java classes.

#### How to verify it
Wait for related changes in the doxo mobile app (I haven't made those yet) then have Firefox as the default browser on an Android device. You should be presented with Chrome - instead of Firefox - as the in-app-browser when trying to sign in.